### PR TITLE
Corrected quaternion transformation

### DIFF
--- a/message_transforms/src/transforms.cpp
+++ b/message_transforms/src/transforms.cpp
@@ -31,9 +31,14 @@ auto transform_message(geometry_msgs::msg::Pose & m) -> void
   const KDL::Vector v(m.position.x, m.position.y, m.position.z);
   const KDL::Rotation r = KDL::Rotation::Quaternion(m.orientation.x, m.orientation.y, m.orientation.z, m.orientation.w);
 
-  // The transformation is a rotation about the x-axis by 180 degrees
-  const KDL::Frame transform(KDL::Rotation::Quaternion(1, 0, 0, 0), KDL::Vector(0, 0, 0));
-  const KDL::Frame v_out = transform * KDL::Frame(r, v);
+  // Map Transform (ENU to NED): The transformation is a rotation about the z-axis by 90 degrees, followed by a rotation
+  // about the x-axis by 180 degrees
+  const KDL::Frame map_transform(KDL::Rotation(0, 1, 0, 1, 0, 0, 0, 0, -1), KDL::Vector(0, 0, 0));
+
+  // Body Transform (FLU to FRD): The transformation is a rotation about the local x-axis by 180 degrees
+  const KDL::Frame body_transform(KDL::Rotation::Quaternion(1, 0, 0, 0), KDL::Vector(0, 0, 0));
+
+  const KDL::Frame v_out = map_transform * KDL::Frame(r, v) * body_transform;
 
   m.position.x = v_out.p.x();
   m.position.y = v_out.p.y();

--- a/message_transforms/src/transforms.cpp
+++ b/message_transforms/src/transforms.cpp
@@ -35,7 +35,7 @@ auto transform_message(geometry_msgs::msg::Pose & m) -> void
   // about the x-axis by 180 degrees
   const KDL::Frame map_transform(KDL::Rotation(0, 1, 0, 1, 0, 0, 0, 0, -1), KDL::Vector(0, 0, 0));
 
-  // Body Transform (FLU to FRD): The transformation is a rotation about the local x-axis by 180 degrees
+  // Body Transform (FLU to FSD): The transformation is a rotation about the local x-axis by 180 degrees
   const KDL::Frame body_transform(KDL::Rotation::Quaternion(1, 0, 0, 0), KDL::Vector(0, 0, 0));
 
   const KDL::Frame v_out = map_transform * KDL::Frame(r, v) * body_transform;


### PR DESCRIPTION
## Changes Made

This PR fixes a transformation bug where the transforms node was applying an incomplete frame transformation, causing downstream marine controllers to interpret the vehicle as being upside down and driving in the wrong direction.

The previous implementation applied a single 180-degree roll via left-multiplication (`transform * KDL::Frame(r, v)`). This resulted in two errors:
1. **Map Frame Error:** Rolling an **ENU** (East-North-Up) position by 180 degrees around the x-axis results in **ESD** (East-South-Down), not the marine standard **NED** (North-East-Down).
2. **Body Frame Error:** Left-multiplying a frame rotates the global map but leaves the local body frame untouched. This meant the orientation output was still in ROS standard **FLU** (Forward-Left-Up), instead of marine standard **FSD** (Forward-Starboard-Down).

## Proposed Fix

Explicitly applies a map rotation (left-multiply) to transform **ENU** to **NED**, and a local body rotation (right-multiply) to transform **FLU** to **FSD**.

## Testing

Tested on gz with [blue](https://github.com/Robotic-Decision-Making-Lab/blue).
